### PR TITLE
팝업 배경색 테마에 맞게 변경

### DIFF
--- a/app/diary/page.tsx
+++ b/app/diary/page.tsx
@@ -323,7 +323,7 @@ export default function DiaryPage() {
 
       {/* 달력 모달 */}
       {showCalendar && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+        <div className="fixed inset-0 popup-backdrop z-50 flex items-center justify-center p-4">
           <div className="glass-strong rounded-3xl p-6 w-full max-w-md mx-auto">
             {/* 달력 헤더 */}
             <div className="flex items-center justify-between mb-6">

--- a/app/globals.css
+++ b/app/globals.css
@@ -855,4 +855,29 @@ html.theme-glassmorphism body,
   min-height: 100vh !important;
 }
 
+/* 기존 팝업 배경 스타일 */
+.popup-backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+/* 뉴모피즘 테마 팝업 배경 - 흰색 */
+.theme-neumorphism .popup-backdrop {
+  background: rgba(255, 255, 255, 0.8) !important;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+/* 글래스모피즘 테마 팝업 배경 - 연보라색 */
+.theme-glassmorphism .popup-backdrop {
+  background: rgba(200, 170, 255, 0.3) !important;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+/* 클래식/미니멀리즘 테마는 기본 검은색 유지 */
+.theme-classic .popup-backdrop,
+.theme-minimalism .popup-backdrop {
+  background: rgba(0, 0, 0, 0.5) !important;
+}
+
 

--- a/components/DatabaseSetupGuide.tsx
+++ b/components/DatabaseSetupGuide.tsx
@@ -44,7 +44,7 @@ CREATE INDEX IF NOT EXISTS idx_diaries_created_at ON diaries(created_at DESC);`
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 popup-backdrop z-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <div className="flex items-center mb-4">

--- a/components/DiaryEditor.tsx
+++ b/components/DiaryEditor.tsx
@@ -126,7 +126,7 @@ export default function DiaryEditor({ diary, onUpdate, onDelete, onClose }: Diar
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-2 sm:p-4">
+    <div className="fixed inset-0 popup-backdrop z-50 flex items-center justify-center p-2 sm:p-4">
       <div className="bg-white rounded-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         {/* 헤더 */}
         <div className="sticky top-0 bg-white border-b border-gray-200 px-4 sm:px-6 py-4">

--- a/components/SubscriptionModal.tsx
+++ b/components/SubscriptionModal.tsx
@@ -30,7 +30,7 @@ export default function SubscriptionModal({ isOpen, onClose, onSubscribe }: Subs
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-30 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 popup-backdrop z-50 flex items-center justify-center p-4">
       <div className="glass-strong rounded-3xl max-w-md w-full max-h-[90vh] overflow-y-auto">
         {/* 헤더 */}
         <div className="sticky top-0 glass-strong border-b border-white/20 px-8 py-6 rounded-t-3xl backdrop-blur-xl">


### PR DESCRIPTION
Adjust popup backdrop colors to match the active theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8072ce1-4d37-4fee-9e5f-99798407b7e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8072ce1-4d37-4fee-9e5f-99798407b7e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>